### PR TITLE
Fix S3BlobStore.finalize() crash and removed unused code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removed unused code [masipcat]
+- Fix S3BlobStore.finalize() crash [masipcat]
 
 
 2.0.1 (2018-09-20)

--- a/guillotina_s3storage/storage.py
+++ b/guillotina_s3storage/storage.py
@@ -20,7 +20,6 @@ import aiobotocore
 import aiohttp
 import asyncio
 import backoff
-import boto3
 import botocore
 import logging
 
@@ -293,9 +292,6 @@ class S3BlobStore:
 
         self._bucket_name = settings['bucket']
 
-        # right now, only used for upload_fileobj in executor
-        self._s3client = boto3.client('s3', **opts)
-
     async def get_bucket_name(self):
         request = get_current_request()
         bucket_name = request._container_id.lower() + '.' + self._bucket_name
@@ -322,7 +318,7 @@ class S3BlobStore:
         self.app = app
 
     async def finalize(self, app=None):
-        self._s3aiosession.close()
+        await self._s3aioclient.close()
 
     async def iterate_bucket(self):
         req = get_current_request()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'setuptools',
         'guillotina>=4.0.0,<5.0.0',
         'aiohttp>3.0.0,<4.0.0',
-        'boto3==1.7.58',
         'ujson',
         'aiobotocore==0.9.4',
         'botocore==1.10.58',


### PR DESCRIPTION
- Removes `boto3` and unused `S3BlobStorage._s3client`
- Fixes this crash:
```
Traceback (most recent call last):
  File "/home/jordi/gits/api/venv/bin/g", line 11, in <module>
    sys.exit(command_runner())
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/commands/__init__.py", line 333, in command_runner
    command.run_command()
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/commands/__init__.py", line 176, in run_command
    run_func(app, settings)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/commands/__init__.py", line 191, in __run
    self.run(self.arguments, settings, app)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/commands/server.py", line 49, in run
    access_log_format=log_format)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/aiohttp/web.py", line 124, in run_app
    loop.run_until_complete(runner.cleanup())
  File "uvloop/loop.pyx", line 1446, in uvloop.loop.Loop.run_until_complete
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/aiohttp/web_runner.py", line 197, in cleanup
    await self._cleanup_server()
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/aiohttp/web_runner.py", line 281, in _cleanup_server
    await self._app.cleanup()
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/aiohttp/web_app.py", line 317, in cleanup
    await self.on_cleanup.send(self)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/aiohttp/signals.py", line 35, in send
    await receiver(*args, **kwargs)  # type: ignore
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/factory/app.py", line 295, in cleanup_app
    await close_utilities(app)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/factory/app.py", line 303, in close_utilities
    await root.del_async_utility(key)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina/factory/content.py", line 91, in del_async_utility
    await lazy_apply(utility.finalize, app=self.app)
  File "/home/jordi/gits/api/venv/lib/python3.6/site-packages/guillotina_s3storage/storage.py", line 326, in finalize
    self._s3aiosession.close()
AttributeError: 'AioSession' object has no attribute 'close'
```