### PR TITLE
Supports max_pool_connections settings as an string value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ include
 extras
 pip-selfcheck.json
 .idea
+venv
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install -e .[test]
   - pip install flake8 codecov pytest-cov
 before_script:
-  - docker run --rm -d -p 19000:9000 --name minio -e MINIO_ACCESS_KEY=xxxxxxxxxx -e MINIO_SECRET_KEY=xxxxxxxxxx minio/minio server /data
+  - docker run --rm -d -p 19000:9000 --name minio -e MINIO_ACCESS_KEY=xxxxxxxxxx -e MINIO_SECRET_KEY=xxxxxxxxxx minio/minio:RELEASE.2019-09-11T19-53-16Z server /data
   - sleep 5
 script:
   - flake8 guillotina_s3storage --config=setup.cfg

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 5.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Cast max_pool_connections from string to integer.
 
 
 5.0.7 (2020-05-21)

--- a/README.rst
+++ b/README.rst
@@ -44,3 +44,10 @@ Using pip (requires Python > 3.7)
     python3.7 -m venv .
     ./bin/pip install -e .[test]
     pre-commit install
+
+Run the tests:
+
+.. code-block:: shell
+
+    docker run --rm -d -p 19000:9000 --name minio -e MINIO_ACCESS_KEY=xxxxxxxxxx -e MINIO_SECRET_KEY=xxxxxxxxxx minio/minio:RELEASE.2019-09-11T19-53-16Z server /data
+    ./bin/pytest -vx guillotina_s3storage/tests

--- a/guillotina_s3storage/storage.py
+++ b/guillotina_s3storage/storage.py
@@ -27,7 +27,7 @@ import logging
 log = logging.getLogger("guillotina_s3storage")
 
 MAX_SIZE = 1073741824
-
+DEFAULT_MAX_POOL_CONNECTIONS = 30
 MIN_UPLOAD_SIZE = 5 * 1024 * 1024
 CHUNK_SIZE = MIN_UPLOAD_SIZE
 MAX_RETRIES = 5
@@ -285,6 +285,12 @@ class S3BlobStore:
         self._aws_access_key = settings["aws_client_id"]
         self._aws_secret_key = settings["aws_client_secret"]
 
+        max_pool_connections = settings.get("max_pool_connections")
+        if max_pool_connections is not None:
+            max_pool_connections = int(max_pool_connections)
+        else:
+            max_pool_connections = DEFAULT_MAX_POOL_CONNECTIONS
+
         opts = dict(
             aws_secret_access_key=self._aws_secret_key,
             aws_access_key_id=self._aws_access_key,
@@ -293,7 +299,7 @@ class S3BlobStore:
             use_ssl=settings.get("ssl", True),
             region_name=settings.get("region_name"),
             config=aiobotocore.config.AioConfig(
-                None, max_pool_connections=settings.get("max_pool_connections", 30)
+                None, max_pool_connections=max_pool_connections
             ),
         )
 

--- a/guillotina_s3storage/tests/fixtures.py
+++ b/guillotina_s3storage/tests/fixtures.py
@@ -6,6 +6,18 @@ import os
 import pytest
 
 
+S3BLOB_STORE_SETTINGS = {
+    "bucket": os.environ.get("S3CLOUD_BUCKET", "testbucket"),
+    "aws_client_id": os.environ.get("S3CLOUD_ID", "x" * 10),
+    "aws_client_secret": os.environ.get("S3CLOUD_SECRET", "x" * 10),  # noqa
+}
+
+
+@pytest.fixture
+def s3blob_store_settings():
+    return S3BLOB_STORE_SETTINGS
+
+
 def settings_configurator(settings):
     if "applications" in settings:
         settings["applications"].append("guillotina_s3storage")
@@ -15,11 +27,7 @@ def settings_configurator(settings):
     settings["load_utilities"]["s3"] = {
         "provides": "guillotina_s3storage.interfaces.IS3BlobStore",
         "factory": "guillotina_s3storage.storage.S3BlobStore",
-        "settings": {
-            "bucket": os.environ.get("S3CLOUD_BUCKET", "testbucket"),
-            "aws_client_id": os.environ.get("S3CLOUD_ID", "x" * 10),
-            "aws_client_secret": os.environ.get("S3CLOUD_SECRET", "x" * 10),  # noqa
-        },
+        "settings": S3BLOB_STORE_SETTINGS
     }
 
     if "S3CLOUD_ID" not in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={"": ["*.txt", "*.rst"], "guillotina_s3storage": ["py.typed"]},
     install_requires=[
         'setuptools',
-        'guillotina>=5.0.0,<7',
+        'guillotina>=5.0.0,<6',
         'aiohttp>3.0.0,<4.0.0',
         'ujson',
         'aiobotocore==0.9.4',
@@ -37,7 +37,8 @@ setup(
         'test': [
             'pytest',
             'pytest-aiohttp',
-            'pytest-docker-fixtures'
+            'pytest-docker-fixtures',
+            'asynctest==0.13.0'
         ]
     }
 )


### PR DESCRIPTION
Fixes different issues with the CI due to the usage of the latest image of minio, technically the solution would need to be added into the pytest fixture images since it also used, or just remove the usage of minio as a fixture and use the docker container that is described in the `README.rst` file and also used in the Travis environment.